### PR TITLE
0.1.3: Add/remove wiregarden to nsswitch.conf on install/remove.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libnss-wiregarden"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Wiregarden Ops <ops@wiregarden.io>"]
 edition = "2018"
 description = "Wiregarden NSS host module"
@@ -31,3 +31,4 @@ assets = [
 	["target/release/libnss_wiregarden.so", "lib/libnss_wiregarden.so.2", "644"],
 	["README.md", "usr/share/doc/libnss-wiregarden/README", "644"],
 ]
+maintainer-scripts = "debian"

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+grep 'hosts:.*wiregarden.*' /etc/nsswitch.conf || \
+	sed -i '/hosts:/ s/$/ wiregarden/' /etc/nsswitch.conf

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+sed -i '/^hosts:/ s/\Wwiregarden$//;s/wiregarden\W\(.*\)/\1/;' /etc/nsswitch.conf


### PR DESCRIPTION
Open 0.1.3 release.

Automatically appends the wiregarden resolver to NSS hosts: on package
install, removes it on uninstall.